### PR TITLE
Update mapgen.cpp to allow jp8 fuel in pumps

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1089,7 +1089,7 @@ class jmapgen_gaspump : public jmapgen_piece
                 fuel = jsi.get_string( "fuel" );
 
                 // may want to not force this, if we want to support other fuels for some reason
-                if( fuel != "gasoline" && fuel != "diesel" ) {
+                if( fuel != "gasoline" && fuel != "diesel" && fuel != "jp8" ) {
                     jsi.throw_error( "invalid fuel", "fuel" );
                 }
             }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Update mapgen.cpp to allow jp8 fuel in pumps"

#### Purpose of change

Should enable #46824 to work.

#### Describe the solution

Add "jp8" as a fuel name.

#### Testing

As part of testing #46824.